### PR TITLE
Show faces display

### DIFF
--- a/templates/admin/show_faces.html
+++ b/templates/admin/show_faces.html
@@ -26,7 +26,7 @@
             <img src="{{ person.photo.url }}" alt="{{ person }}" title="{{ person }}" />
         </div>
         {% empty %}
-        <p>{% trans "No faces to show" %}
+        <p>{% trans "No faces to show" %}</p>
         {% endfor %}
     </div>
 </div>

--- a/templates/admin/show_faces.html
+++ b/templates/admin/show_faces.html
@@ -12,8 +12,8 @@
         margin: 5px;
     }
     #face_container>.face img {
-        width: 100%;
-        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
     }
 </style>
 {% endblock %}

--- a/templates/admin/show_faces.html
+++ b/templates/admin/show_faces.html
@@ -8,12 +8,12 @@
     #face_container>.face{
         display: inline-block;
         width: 200px;
-        height: 200px;
+        height: 300px;
         margin: 5px;
     }
     #face_container>.face img {
         max-width: 100%;
-        max-height: 100%;
+        max-height: 200px;
     }
 </style>
 {% endblock %}
@@ -23,7 +23,10 @@
     <div class="grp-row" id="face_container">
         {% for person in people %}
         <div class="face">
-            <img src="{{ person.photo.url }}" alt="{{ person }}" title="{{ person }}" />
+            <img src="{{ person.photo.url }}" alt="{{ person }}" title="{{ person }}" /><br />
+            <strong>ID</strong> {{ person.id }}<br />
+            <strong>Name</strong> {{ person.name }}<br />
+            <strong>Phone</strong> {{ person.phone }}<br />
         </div>
         {% empty %}
         <p>{% trans "No faces to show" %}</p>

--- a/templates/admin/show_faces.html
+++ b/templates/admin/show_faces.html
@@ -24,7 +24,7 @@
         {% for person in people %}
         <div class="face">
             <img src="{{ person.photo.url }}" alt="{{ person }}" title="{{ person }}" /><br />
-            <strong>ID</strong> {{ person.id }}<br />
+            <strong>ID</strong> {{ person.registration_card.number }}<br />
             <strong>Name</strong> {{ person.name }}<br />
             <strong>Phone</strong> {{ person.phone }}<br />
         </div>


### PR DESCRIPTION
This handles both not stretching the photos in the show_faces view, and captioning the photos with name/id/phone.

The 'id' used is the `person.registration_card.number`, which was also what is shown in `Person.__unicode__`'s output. If that isn't the ID needed here, I'm happy to swap it out for whichever attribute is useful.

I'm saving the rotating of the photos, which remains a mystery, for another PR, but this seemed like it would be a help already so I'll submit this one now.

Any front-end work will also be its own PR.