### PR TITLE
scale and rotate photos on upload

### DIFF
--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -5,7 +5,7 @@
     var cookie = require("cookie");
     var fixOrientation = require('fix-orientation');
     var toBlob = require("canvas-to-blob");
-    toBlob.init()
+    toBlob.init();
 
     function uploadFile(blob) {
         var imageDropzone = document.getElementById('reg-image-uploader').dropzone;

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -5,7 +5,7 @@
     var cookie = require("cookie");
     var fixOrientation = require('fix-orientation');
     var toBlob = require("canvas-to-blob");
-    toBlob.init();
+    toBlob.init(); //add toBlob method to canvas prototype if not present
 
     function uploadFile(blob) {
         var imageDropzone = document.getElementById('reg-image-uploader').dropzone;
@@ -23,7 +23,7 @@
             total: blob.size
         };
         blob.webkitRelativePath = oldFile.webkitRelativePath;
-        // left as blob because of potential incompatibility with file API
+        // left as blob because of potential incompatibilities with File API
         imageDropzone.files[0] = blob;
         imageDropzone.processQueue();
     }
@@ -44,6 +44,7 @@
         var ctx = canvas.getContext("2d");
         ctx.scale(scaleRatio, scaleRatio);
         ctx.drawImage(image, 0, 0);
+        // turn scaled image into a jpg blob with 100% quality
         canvas.toBlob(uploadFile, "image/jpeg", 1);
     }
 
@@ -51,7 +52,9 @@
         var reader = new FileReader();
         reader.onload = (function(readerFile) {
             return function(e) {
+                // read DataURL and reorient image if EXIF information says so
                 fixOrientation(e.target.result, { image: true }, function (fixed, image) {
+                    // Don't try to scale the returned image element until it's fully loaded
                     var waitForImg = setInterval(function() {
                         if (image.naturalWidth && image.naturalHeight) {
                             clearInterval(waitForImg);

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -23,6 +23,7 @@
             total: blob.size
         };
         blob.webkitRelativePath = oldFile.webkitRelativePath;
+        // left as blob because of potential incompatibility with file API
         imageDropzone.files[0] = blob;
         imageDropzone.processQueue();
     }
@@ -34,6 +35,7 @@
         if (sourceWidth > maxWidth || sourceHeight > maxHeight) {
             var widthRatio = maxWidth / sourceWidth;
             var heightRatio = maxHeight / sourceHeight;
+            // Take the ratio that makes the bigger difference
             scaleRatio = Math.min(widthRatio, heightRatio);
         }
         var canvas = document.createElement("canvas");

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -3,16 +3,79 @@
 
     var Dropzone = require("dropzone");
     var cookie = require("cookie");
+    var fixOrientation = require('fix-orientation');
+    var toBlob = require("canvas-to-blob");
+    toBlob.init()
+
+    function uploadFile(blob) {
+        var oldFile = imageDropzone.files[0];
+        blob.accepted = oldFile.accepted;
+        blob.lastModified = Date.now();
+        blob.lastModifiedDate = new Date();
+        blob.name = oldFile.name;
+        blob.previewElement = oldFile.previewElement;
+        blob.previewTemplate = oldFile.previewTemplate;
+        blob.status = oldFile.status;
+        blob.upload = {
+            bytesSent: 0,
+            progress: 0,
+            total: blob.size
+        };
+        blob.webkitRelativePath = oldFile.webkitRelativePath;
+        imageDropzone.files[0] = blob;
+        imageDropzone.processQueue();
+    }
+
+    function scaleImageToCanvas(image, dwidth, dheight) {
+        var scaleRatio = 1;
+        var sourceWidth = image.naturalWidth;
+        var sourceHeight = image.naturalHeight;
+        if (sourceWidth > dwidth || sourceHeight > dheight) {
+            var widthRatio = dwidth / sourceWidth;
+            var heightRatio = dheight / sourceHeight;
+            scaleRatio = Math.min(widthRatio, heightRatio);
+        }
+        var canvas = document.createElement("canvas");
+        canvas.width = sourceWidth * scaleRatio;
+        canvas.height = sourceHeight * scaleRatio;
+        var ctx = canvas.getContext("2d");
+        ctx.scale(scaleRatio, scaleRatio);
+        ctx.drawImage(image, 0, 0);
+        canvas.toBlob(uploadFile, "image/jpeg", 1);
+    }
+
+    function rotateAndScaleFile(file, dwidth, dheight) {
+        var reader = new FileReader();
+        reader.onload = (function(readerFile) {
+            return function(e) {
+                fixOrientation(e.target.result, { image: true }, function (fixed, image) {
+                    var waitForImg = setInterval(function() {
+                        if (image.naturalWidth && image.naturalHeight) {
+                            clearInterval(waitForImg);
+                            scaleImageToCanvas(image, dwidth, dheight);
+                        }
+                    }, 30);
+                });
+            };
+        })(file);
+        reader.readAsDataURL(file);
+    }
 
     // Dropzone options
     Dropzone.options.regImageUploader = {
         headers: {'X-CSRFToken': cookie.parse(document.cookie).csrftoken},
         acceptedFiles: "image/*",
+        autoProcessQueue: false,
         maxFiles: 1,
+
         init: function() {
+            window.imageDropzone = this;
             this.on("success", function(file, response) {
                 var form = document.forms.mainForm;
                 form.photo.value = response.filename;
+            });
+            this.on("addedfile", function(file){
+                rotateAndScaleFile(file, 600, 800);
             });
         }
     };

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -26,13 +26,13 @@
         imageDropzone.processQueue();
     }
 
-    function scaleImageToCanvas(image, dwidth, dheight) {
+    function scaleImageToCanvas(image, maxWidth, maxHeight) {
         var scaleRatio = 1;
         var sourceWidth = image.naturalWidth;
         var sourceHeight = image.naturalHeight;
-        if (sourceWidth > dwidth || sourceHeight > dheight) {
-            var widthRatio = dwidth / sourceWidth;
-            var heightRatio = dheight / sourceHeight;
+        if (sourceWidth > maxWidth || sourceHeight > maxHeight) {
+            var widthRatio = maxWidth / sourceWidth;
+            var heightRatio = maxHeight / sourceHeight;
             scaleRatio = Math.min(widthRatio, heightRatio);
         }
         var canvas = document.createElement("canvas");
@@ -44,7 +44,7 @@
         canvas.toBlob(uploadFile, "image/jpeg", 1);
     }
 
-    function rotateAndScaleFile(file, dwidth, dheight) {
+    function rotateAndScaleFile(file, maxWidth, maxHeight) {
         var reader = new FileReader();
         reader.onload = (function(readerFile) {
             return function(e) {
@@ -52,7 +52,7 @@
                     var waitForImg = setInterval(function() {
                         if (image.naturalWidth && image.naturalHeight) {
                             clearInterval(waitForImg);
-                            scaleImageToCanvas(image, dwidth, dheight);
+                            scaleImageToCanvas(image, maxWidth, maxHeight);
                         }
                     }, 30);
                 });

--- a/js/fileupload.js
+++ b/js/fileupload.js
@@ -8,6 +8,7 @@
     toBlob.init()
 
     function uploadFile(blob) {
+        var imageDropzone = document.getElementById('reg-image-uploader').dropzone;
         var oldFile = imageDropzone.files[0];
         blob.accepted = oldFile.accepted;
         blob.lastModified = Date.now();
@@ -69,7 +70,6 @@
         maxFiles: 1,
 
         init: function() {
-            window.imageDropzone = this;
             this.on("success", function(file, response) {
                 var form = document.forms.mainForm;
                 form.photo.value = response.filename;

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   },
   "dependencies": {
     "browserify": "^9.0.8",
+    "canvas-to-blob": "0.0.0",
     "cookie": "^0.2.3",
     "dropzone": "^4.2.0",
+    "fix-orientation": "0.0.2",
     "gulp": "^3.8.11",
     "gulp-gzip": "^1.1.0",
     "gulp-livereload": "^3.8.0",


### PR DESCRIPTION
This rotates images based on their EXIF information, if necessary, and scales them to a max size of 600x800 pixels prior to uploading them to the server.

Compatibility is lacking with IE <=9 and with Opera Mini, but not pre-installed modern browsers. And for those cases, there is still the stage 2 form as a fallback.